### PR TITLE
Add --skip-permissions flag for hook auto-approval

### DIFF
--- a/src/cli.zig
+++ b/src/cli.zig
@@ -25,7 +25,7 @@ pub fn run(args: []const []const u8, allocator: std.mem.Allocator) !u8 {
         return 0;
     }
     if (eq(sub, "init")) return runInitCmd(args, allocator);
-    if (eq(sub, "rewrite")) return claude.runRewrite(allocator);
+    if (eq(sub, "rewrite")) return claude.runRewrite(args, allocator);
     if (eq(sub, "run")) {
         if (args.len < 3) {
             try compat.writeStderr("usage: ztk run <cmd> [args...]\n");
@@ -46,10 +46,15 @@ pub fn run(args: []const []const u8, allocator: std.mem.Allocator) !u8 {
 
 fn runInitCmd(args: []const []const u8, allocator: std.mem.Allocator) !u8 {
     var global = false;
+    var skip_permissions = false;
     for (args[2..]) |a| {
         if (eq(a, "-g") or eq(a, "--global")) global = true;
+        if (eq(a, "--skip-permissions")) skip_permissions = true;
     }
-    try claude.runInit(allocator, global);
+    claude.runInit(allocator, global, skip_permissions) catch |err| switch (err) {
+        error.HookFlagMismatch => return 1,
+        else => return err,
+    };
     return 0;
 }
 
@@ -59,8 +64,19 @@ fn usage() !void {
         \\
         \\commands:
         \\  run <cmd> [args...]   execute command and emit compact output
-        \\  init [-g]             install Claude Code PreToolUse hook
-        \\  rewrite               PreToolUse hook handler (reads stdin)
+        \\  init [-g] [--skip-permissions]
+        \\                        install Claude Code PreToolUse hook.
+        \\                        -g writes to $HOME/.claude/settings.json,
+        \\                        otherwise ./.claude/settings.json.
+        \\                        --skip-permissions writes the hook command
+        \\                        as `ztk rewrite --skip-permissions` so the
+        \\                        hook emits "allow" instead of "ask".
+        \\  rewrite [--skip-permissions]
+        \\                        PreToolUse hook handler (reads stdin).
+        \\                        --skip-permissions emits "allow" instead of
+        \\                        "ask" so auto-mode users aren't prompted on
+        \\                        every rewrite. permissions.deny / .ask rules
+        \\                        still apply to the rewritten command.
         \\  stats                 print savings stats
         \\  update                update this ztk executable from GitHub
         \\  version               print version

--- a/src/hooks/claude_init.zig
+++ b/src/hooks/claude_init.zig
@@ -6,10 +6,14 @@ const compat = @import("../compat.zig");
 /// Install the ztk PreToolUse hook into Claude Code's settings.
 /// If `global` is true, target `$HOME/.claude/settings.json`;
 /// otherwise target `./.claude/settings.json` in the current directory.
-pub fn runInit(allocator: std.mem.Allocator, global: bool) !void {
+/// If `skip_permissions` is true, the hook command is written as
+/// `ztk rewrite --skip-permissions` so the hook emits "allow" instead
+/// of "ask" — auto-mode users aren't prompted on every rewrite, while
+/// permissions.deny / .ask rules still apply to the rewritten command.
+pub fn runInit(allocator: std.mem.Allocator, global: bool, skip_permissions: bool) !void {
     const path = try resolveSettingsPath(allocator, global);
     defer allocator.free(path);
-    const status = try writeInit(allocator, path);
+    const status = try writeInit(allocator, path, skip_permissions);
     switch (status) {
         .already_installed => try compat.writeStdout("ztk PreToolUse hook already installed\n"),
         .installed => {
@@ -17,28 +21,51 @@ pub fn runInit(allocator: std.mem.Allocator, global: bool) !void {
             const msg = try std.fmt.bufPrint(&buf, "Installed ztk PreToolUse hook in {s}\n", .{path});
             try compat.writeStdout(msg);
         },
+        .conflict => {
+            var buf: [512]u8 = undefined;
+            const msg = std.fmt.bufPrint(
+                &buf,
+                "ztk: an existing ztk PreToolUse hook in {s} uses different flags. Remove that entry and re-run.\n",
+                .{path},
+            ) catch "ztk: existing ztk hook uses different flags; remove it and re-run.\n";
+            try compat.writeStderr(msg);
+            return error.HookFlagMismatch;
+        },
     }
 }
 
-pub const InstallStatus = enum { installed, already_installed };
+pub const InstallStatus = enum { installed, already_installed, conflict };
 
-/// Ensure `settings_path` contains a PreToolUse hook that invokes
-/// `ztk rewrite` for Bash commands. Creates parent dirs and the file
-/// if missing, merges into an existing object otherwise. Returns
-/// `.already_installed` if a matching hook is already present.
-pub fn writeInit(allocator: std.mem.Allocator, settings_path: []const u8) !InstallStatus {
+/// Ensure `settings_path` contains a PreToolUse hook that invokes the
+/// computed ztk rewrite command for Bash. Creates parent dirs and the
+/// file if missing, merges into an existing object otherwise.
+/// Returns `.already_installed` if the desired exact command is present,
+/// `.conflict` if a different ztk-rewrite variant is present (refuses to
+/// append a duplicate), and `.installed` after a fresh install or merge.
+pub fn writeInit(
+    allocator: std.mem.Allocator,
+    settings_path: []const u8,
+    skip_permissions: bool,
+) !InstallStatus {
     if (std.fs.path.dirname(settings_path)) |dir| {
         compat.makePath(dir) catch |e| switch (e) {
             error.PathAlreadyExists => {},
             else => return e,
         };
     }
+    const desired_cmd = if (skip_permissions) "ztk rewrite --skip-permissions" else "ztk rewrite";
     const existing = readIfExists(allocator, settings_path) catch |e| return e;
     defer if (existing) |b| allocator.free(b);
     if (existing) |bytes| {
-        if (std.mem.indexOf(u8, bytes, claude.hook_command) != null) return .already_installed;
+        // Match the JSON-quoted command exactly so "ztk rewrite" doesn't
+        // collide with "ztk rewrite --skip-permissions".
+        var quoted_buf: [128]u8 = undefined;
+        const quoted = std.fmt.bufPrint(&quoted_buf, "\"{s}\"", .{desired_cmd}) catch return error.OutOfMemory;
+        if (std.mem.indexOf(u8, bytes, quoted) != null) return .already_installed;
+        // Any other ztk rewrite variant present → conflict.
+        if (std.mem.indexOf(u8, bytes, "\"ztk rewrite") != null) return .conflict;
     }
-    const merged = try buildSettings(allocator, existing);
+    const merged = try buildSettings(allocator, existing, desired_cmd);
     defer allocator.free(merged);
     try writeAtomic(settings_path, merged);
     return .installed;

--- a/src/hooks/claude_init_build.zig
+++ b/src/hooks/claude_init_build.zig
@@ -4,8 +4,10 @@ const claude = @import("claude.zig");
 /// Build the serialized settings.json contents that should replace any
 /// existing file at the hook install path. `existing` is the prior file
 /// bytes (or null) — if present and parseable, other top-level keys are
-/// preserved and only the hooks.PreToolUse array is mutated.
-pub fn buildSettings(allocator: std.mem.Allocator, existing: ?[]const u8) ![]u8 {
+/// preserved and only the hooks.PreToolUse array is mutated. The hook
+/// `command` field is set to `hook_command` (e.g. "ztk rewrite" or
+/// "ztk rewrite --skip-permissions").
+pub fn buildSettings(allocator: std.mem.Allocator, existing: ?[]const u8, hook_command: []const u8) ![]u8 {
     var arena = std.heap.ArenaAllocator.init(allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -13,7 +15,7 @@ pub fn buildSettings(allocator: std.mem.Allocator, existing: ?[]const u8) ![]u8 
     var root = try loadOrInit(a, existing);
     var hooks = try ensureObject(a, &root, "hooks");
     var pre = try ensureArray(a, hooks, "PreToolUse");
-    try pre.append(try buildEntry(a));
+    try pre.append(try buildEntry(a, hook_command));
     try hooks.put(a, "PreToolUse", .{ .array = pre });
 
     var aw: std.Io.Writer.Allocating = .init(allocator);
@@ -47,13 +49,13 @@ fn ensureArray(a: std.mem.Allocator, parent: *std.json.ObjectMap, key: []const u
     return std.json.Array.init(a);
 }
 
-fn buildEntry(a: std.mem.Allocator) !std.json.Value {
+fn buildEntry(a: std.mem.Allocator, hook_command: []const u8) !std.json.Value {
     var entry = try emptyObject(a);
     try entry.put(a, "matcher", .{ .string = claude.hook_matcher });
 
     var inner = try emptyObject(a);
     try inner.put(a, "type", .{ .string = "command" });
-    try inner.put(a, "command", .{ .string = claude.hook_command });
+    try inner.put(a, "command", .{ .string = hook_command });
 
     var hooks_arr = std.json.Array.init(a);
     try hooks_arr.append(.{ .object = inner });
@@ -67,7 +69,7 @@ fn emptyObject(a: std.mem.Allocator) !std.json.ObjectMap {
 
 test "buildSettings creates fresh JSON with hook" {
     const allocator = std.testing.allocator;
-    const out = try buildSettings(allocator, null);
+    const out = try buildSettings(allocator, null, "ztk rewrite");
     defer allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"PreToolUse\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "ztk rewrite") != null);
@@ -77,7 +79,7 @@ test "buildSettings creates fresh JSON with hook" {
 test "buildSettings preserves existing top-level keys" {
     const allocator = std.testing.allocator;
     const prior = "{\"theme\":\"dark\",\"permissions\":{\"deny\":[\"Bash(rm -rf*)\"]}}";
-    const out = try buildSettings(allocator, prior);
+    const out = try buildSettings(allocator, prior, "ztk rewrite");
     defer allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"theme\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"permissions\"") != null);
@@ -87,9 +89,16 @@ test "buildSettings preserves existing top-level keys" {
 test "buildSettings appends to existing PreToolUse array" {
     const allocator = std.testing.allocator;
     const prior = "{\"hooks\":{\"PreToolUse\":[{\"matcher\":\"Edit\",\"hooks\":[]}]}}";
-    const out = try buildSettings(allocator, prior);
+    const out = try buildSettings(allocator, prior, "ztk rewrite");
     defer allocator.free(out);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"Edit\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "\"Bash\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, out, "ztk rewrite") != null);
+}
+
+test "buildSettings writes the supplied hook command verbatim" {
+    const allocator = std.testing.allocator;
+    const out = try buildSettings(allocator, null, "ztk rewrite --skip-permissions");
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "ztk rewrite --skip-permissions") != null);
 }

--- a/src/hooks/claude_rewrite.zig
+++ b/src/hooks/claude_rewrite.zig
@@ -24,7 +24,22 @@ const compat = @import("../compat.zig");
 ///    "updatedInput": {"command": "ztk run <original>"}}}
 ///
 /// No output (empty stdout) means "no opinion, let Claude Code decide".
-pub fn runRewrite(allocator: std.mem.Allocator) !u8 {
+///
+/// Flags (parsed from args[2..]):
+///   --skip-permissions   emit "allow" instead of the default "ask".
+///       Hook-emitted "ask" cannot be overridden by user permissions.allow
+///       rules, so the default forces a prompt for every rewrite. With this
+///       flag the rewrite is approved by the hook; user permissions.deny
+///       and permissions.ask rules still fire on the rewritten command
+///       (Claude Code always evaluates those regardless of hook decision).
+pub fn runRewrite(args: []const []const u8, allocator: std.mem.Allocator) !u8 {
+    var skip_permissions = false;
+    if (args.len > 2) {
+        for (args[2..]) |a| {
+            if (std.mem.eql(u8, a, "--skip-permissions")) skip_permissions = true;
+        }
+    }
+
     const stdin_bytes = readStdin(allocator) catch return 0;
     defer allocator.free(stdin_bytes);
 
@@ -47,7 +62,7 @@ pub fn runRewrite(allocator: std.mem.Allocator) !u8 {
     }
 
     debugLog("rewrite", command) catch {};
-    try emitRewrite(allocator, command);
+    try emitRewrite(allocator, command, skip_permissions);
     return 0;
 }
 
@@ -103,20 +118,32 @@ pub fn hasFilterFor(command: []const u8) bool {
     return false;
 }
 
-fn emitRewrite(allocator: std.mem.Allocator, command: []const u8) !void {
-    // Claude Code PreToolUse hook JSON format.
-    // permissionDecision="ask" + updatedInput triggers the rewrite flow.
+fn emitRewrite(allocator: std.mem.Allocator, command: []const u8, skip_permissions: bool) !void {
+    const payload = try buildRewritePayload(allocator, command, skip_permissions);
+    defer allocator.free(payload);
+    try compat.writeStdout(payload);
+}
+
+/// Build the PreToolUse hook JSON payload that rewrites `command` to
+/// `ztk run <command>`. Decision is "allow" when `skip_permissions` is
+/// true (auto-mode friendly), otherwise "ask" (forces a confirmation
+/// prompt for every rewrite). Both forms still let Claude Code evaluate
+/// permissions.deny and permissions.ask rules on the rewritten command.
+pub fn buildRewritePayload(
+    allocator: std.mem.Allocator,
+    command: []const u8,
+    skip_permissions: bool,
+) ![]u8 {
+    const decision: []const u8 = if (skip_permissions) "allow" else "ask";
     const rewritten = try std.fmt.allocPrint(allocator, "ztk run {s}", .{command});
     defer allocator.free(rewritten);
     const escaped = try jsonEscape(allocator, rewritten);
     defer allocator.free(escaped);
-    var buf: [8192]u8 = undefined;
-    const payload = try std.fmt.bufPrint(
-        &buf,
-        "{{\"hookSpecificOutput\":{{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"ask\",\"permissionDecisionReason\":\"ztk auto-rewrite for token savings\",\"updatedInput\":{{\"command\":\"{s}\"}}}}}}\n",
-        .{escaped},
+    return std.fmt.allocPrint(
+        allocator,
+        "{{\"hookSpecificOutput\":{{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"{s}\",\"permissionDecisionReason\":\"ztk auto-rewrite for token savings\",\"updatedInput\":{{\"command\":\"{s}\"}}}}}}\n",
+        .{ decision, escaped },
     );
-    try compat.writeStdout(payload);
 }
 
 fn jsonEscape(allocator: std.mem.Allocator, input: []const u8) ![]u8 {
@@ -166,4 +193,29 @@ test "jsonEscape handles quotes and backslashes" {
     const out = try jsonEscape(allocator, "cmd \"arg\"\n\\");
     defer allocator.free(out);
     try std.testing.expectEqualStrings("cmd \\\"arg\\\"\\n\\\\", out);
+}
+
+test "buildRewritePayload defaults to ask" {
+    const allocator = std.testing.allocator;
+    const out = try buildRewritePayload(allocator, "git status", false);
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"permissionDecision\":\"ask\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"permissionDecision\":\"allow\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"command\":\"ztk run git status\"") != null);
+}
+
+test "buildRewritePayload with skip_permissions emits allow" {
+    const allocator = std.testing.allocator;
+    const out = try buildRewritePayload(allocator, "git status", true);
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"permissionDecision\":\"allow\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"permissionDecision\":\"ask\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, out, "\"command\":\"ztk run git status\"") != null);
+}
+
+test "buildRewritePayload escapes embedded quotes in command" {
+    const allocator = std.testing.allocator;
+    const out = try buildRewritePayload(allocator, "git commit -m \"x\"", true);
+    defer allocator.free(out);
+    try std.testing.expect(std.mem.indexOf(u8, out, "ztk run git commit -m \\\"x\\\"") != null);
 }

--- a/src/hooks/claude_test.zig
+++ b/src/hooks/claude_test.zig
@@ -19,7 +19,7 @@ test "runInit writes a fresh settings file into tmpdir" {
     const settings = try std.fs.path.join(allocator, &.{ base, "settings.json" });
     defer allocator.free(settings);
 
-    const status = try claude_init.writeInit(allocator, settings);
+    const status = try claude_init.writeInit(allocator, settings, false);
     try std.testing.expectEqual(claude_init.InstallStatus.installed, status);
 
     const file = try compat.openFile(settings, .{});
@@ -46,8 +46,8 @@ test "runInit is idempotent when hook is already present" {
     const settings = try std.fs.path.join(allocator, &.{ base, "settings.json" });
     defer allocator.free(settings);
 
-    _ = try claude_init.writeInit(allocator, settings);
-    const status2 = try claude_init.writeInit(allocator, settings);
+    _ = try claude_init.writeInit(allocator, settings, false);
+    const status2 = try claude_init.writeInit(allocator, settings, false);
     try std.testing.expectEqual(claude_init.InstallStatus.already_installed, status2);
 }
 
@@ -66,7 +66,7 @@ test "runInit preserves unrelated top-level keys when merging" {
         defer compat.closeFile(f);
         try compat.writeFileAll(f, "{\"theme\":\"dark\"}");
     }
-    _ = try claude_init.writeInit(allocator, settings);
+    _ = try claude_init.writeInit(allocator, settings, false);
 
     const f = try compat.openFile(settings, .{});
     defer compat.closeFile(f);
@@ -74,6 +74,56 @@ test "runInit preserves unrelated top-level keys when merging" {
     defer allocator.free(bytes);
     try std.testing.expect(std.mem.indexOf(u8, bytes, "\"theme\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, bytes, "ztk rewrite") != null);
+}
+
+test "runInit with skip_permissions writes flagged hook command" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmpRealPath(allocator, &tmp);
+    defer allocator.free(base);
+    const settings = try std.fs.path.join(allocator, &.{ base, "settings.json" });
+    defer allocator.free(settings);
+
+    const status = try claude_init.writeInit(allocator, settings, true);
+    try std.testing.expectEqual(claude_init.InstallStatus.installed, status);
+
+    const f = try compat.openFile(settings, .{});
+    defer compat.closeFile(f);
+    const bytes = try compat.readFileToEndAlloc(f, allocator, 1 << 20);
+    defer allocator.free(bytes);
+    try std.testing.expect(std.mem.indexOf(u8, bytes, "\"ztk rewrite --skip-permissions\"") != null);
+}
+
+test "runInit reports conflict when existing hook uses different flag" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmpRealPath(allocator, &tmp);
+    defer allocator.free(base);
+    const settings = try std.fs.path.join(allocator, &.{ base, "settings.json" });
+    defer allocator.free(settings);
+
+    _ = try claude_init.writeInit(allocator, settings, false);
+    const status2 = try claude_init.writeInit(allocator, settings, true);
+    try std.testing.expectEqual(claude_init.InstallStatus.conflict, status2);
+}
+
+test "runInit idempotent on flagged re-install" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const base = try tmpRealPath(allocator, &tmp);
+    defer allocator.free(base);
+    const settings = try std.fs.path.join(allocator, &.{ base, "settings.json" });
+    defer allocator.free(settings);
+
+    _ = try claude_init.writeInit(allocator, settings, true);
+    const status2 = try claude_init.writeInit(allocator, settings, true);
+    try std.testing.expectEqual(claude_init.InstallStatus.already_installed, status2);
 }
 
 test "sample Claude hook JSON yields expected command" {


### PR DESCRIPTION
Adds a --skip-permissions flag for users running Claude Code in auto-mode who don't want a confirmation prompt on every Bash command ztk rewrites.

`ztk rewrite --skip-permissions` emits permissionDecision: "allow" on the PreToolUse hook instead of the default "ask". The user's permissions.deny / permissions.ask rules in settings.json still apply to the rewritten command, so dangerous patterns can be blocked or gated there, and auto-mode may still device to block before invoking Bash commands.

`ztk init --skip-permissions` installs the hook with the flag baked into the command in settings.json, so users don't have to hand-edit the JSON.

I didn't want to make assumptions about why 'ask' is hardcoded - and kept default behavior (ask) in case people are running in a strict setup.

No short flag (-s) added; happy to include one if preferred.