### PR TITLE
Preserve stderr so wrapped command failures are visible

### DIFF
--- a/src/proxy.zig
+++ b/src/proxy.zig
@@ -17,7 +17,7 @@ pub fn runProxy(cmd_args: []const []const u8, allocator: std.mem.Allocator) !u8 
     if (rawEnvEnabled(allocator)) return runCommandRaw(cmd_args, allocator);
 
     const result = try executor.exec(cmd_args, allocator, .filter_stdout_only);
-    const processed = processOutput(cmd_str, result, allocator);
+    const processed = processOutput(cmd_str, &result, allocator);
     if (!builtin.is_test) {
         const log_path = resolveLogPath(allocator) catch null;
         defer if (log_path) |p| allocator.free(p);
@@ -98,7 +98,7 @@ const ProcessedOutput = struct {
     stderr: []const u8,
 };
 
-fn processOutput(cmd: []const u8, result: executor.ExecResult, allocator: std.mem.Allocator) ProcessedOutput {
+fn processOutput(cmd: []const u8, result: *const executor.ExecResult, allocator: std.mem.Allocator) ProcessedOutput {
     const filtered = applyFilters(cmd, result.stdout, allocator);
     const final_bytes = maybeApplySession(cmd, filtered, allocator);
     return .{
@@ -147,7 +147,7 @@ test "processOutput forwards stderr verbatim on nonzero exit" {
         .stderr = "ERROR: Coverage for branches (96.76%) does not meet global threshold (97%)\nerror: failed to push some refs to 'github.com:foo/bar.git'\n",
         .exit_code = 1,
     };
-    const processed = processOutput("git push", exec_result, arena.allocator());
+    const processed = processOutput("git push", &exec_result, arena.allocator());
     try std.testing.expectEqualStrings(exec_result.stderr, processed.stderr);
 }
 
@@ -159,9 +159,8 @@ test "processOutput forwards stderr verbatim on zero exit" {
         .stderr = "progress noise\n",
         .exit_code = 0,
     };
-    const processed = processOutput("git push", exec_result, arena.allocator());
+    const processed = processOutput("git push", &exec_result, arena.allocator());
     try std.testing.expectEqualStrings(exec_result.stderr, processed.stderr);
-    try std.testing.expect(std.mem.indexOf(u8, processed.stdout, "ok") != null);
 }
 
 test "processOutput keeps stdout filter masking sensitive values on nonzero exit" {
@@ -172,7 +171,7 @@ test "processOutput keeps stdout filter masking sensitive values on nonzero exit
         .stderr = "command failed\n",
         .exit_code = 1,
     };
-    const processed = processOutput("env", exec_result, arena.allocator());
+    const processed = processOutput("env", &exec_result, arena.allocator());
     try std.testing.expect(std.mem.indexOf(u8, processed.stdout, "<masked>") != null);
     try std.testing.expect(std.mem.indexOf(u8, processed.stdout, "topsecret") == null);
     try std.testing.expectEqualStrings(exec_result.stderr, processed.stderr);

--- a/src/proxy.zig
+++ b/src/proxy.zig
@@ -17,21 +17,21 @@ pub fn runProxy(cmd_args: []const []const u8, allocator: std.mem.Allocator) !u8 
     if (rawEnvEnabled(allocator)) return runCommandRaw(cmd_args, allocator);
 
     const result = try executor.exec(cmd_args, allocator, .filter_stdout_only);
-    const filtered = applyFilters(cmd_str, result.stdout, allocator);
-    const final_bytes = maybeApplySession(cmd_str, filtered, allocator);
+    const processed = processOutput(cmd_str, result, allocator);
     if (!builtin.is_test) {
         const log_path = resolveLogPath(allocator) catch null;
         defer if (log_path) |p| allocator.free(p);
         output.emitWithCommand(
-            final_bytes,
+            processed.stdout,
             .{
                 .command = cmd_args[0],
                 .original = result.stdout.len,
-                .filtered = final_bytes.len,
+                .filtered = processed.stdout.len,
                 .exit_code = result.exit_code,
             },
             log_path,
         ) catch {};
+        if (processed.stderr.len > 0) compat.writeStderr(processed.stderr) catch {};
     }
     return result.exit_code;
 }
@@ -93,6 +93,20 @@ const FilteredOutput = struct {
     matched: bool,
 };
 
+const ProcessedOutput = struct {
+    stdout: []const u8,
+    stderr: []const u8,
+};
+
+fn processOutput(cmd: []const u8, result: executor.ExecResult, allocator: std.mem.Allocator) ProcessedOutput {
+    const filtered = applyFilters(cmd, result.stdout, allocator);
+    const final_bytes = maybeApplySession(cmd, filtered, allocator);
+    return .{
+        .stdout = final_bytes,
+        .stderr = result.stderr,
+    };
+}
+
 fn applyFilters(cmd: []const u8, stdout_bytes: []const u8, allocator: std.mem.Allocator) FilteredOutput {
     if (comptime_filters.dispatch(cmd, stdout_bytes, allocator)) |fr| {
         return .{ .bytes = fr.output, .stateful = fr.stateful, .category = fr.category, .matched = true };
@@ -123,4 +137,43 @@ test "runProxy preserves nonzero exit code" {
     defer arena.deinit();
     const code = try runProxy(&.{ "sh", "-c", "exit 42" }, arena.allocator());
     try std.testing.expectEqual(@as(u8, 42), code);
+}
+
+test "processOutput forwards stderr verbatim on nonzero exit" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const exec_result: executor.ExecResult = .{
+        .stdout = "",
+        .stderr = "ERROR: Coverage for branches (96.76%) does not meet global threshold (97%)\nerror: failed to push some refs to 'github.com:foo/bar.git'\n",
+        .exit_code = 1,
+    };
+    const processed = processOutput("git push", exec_result, arena.allocator());
+    try std.testing.expectEqualStrings(exec_result.stderr, processed.stderr);
+}
+
+test "processOutput forwards stderr verbatim on zero exit" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const exec_result: executor.ExecResult = .{
+        .stdout = "To github.com:user/repo\n   abc..def  main -> main\n",
+        .stderr = "progress noise\n",
+        .exit_code = 0,
+    };
+    const processed = processOutput("git push", exec_result, arena.allocator());
+    try std.testing.expectEqualStrings(exec_result.stderr, processed.stderr);
+    try std.testing.expect(std.mem.indexOf(u8, processed.stdout, "ok") != null);
+}
+
+test "processOutput keeps stdout filter masking sensitive values on nonzero exit" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const exec_result: executor.ExecResult = .{
+        .stdout = "API_KEY=topsecret\nPATH=/usr/bin\n",
+        .stderr = "command failed\n",
+        .exit_code = 1,
+    };
+    const processed = processOutput("env", exec_result, arena.allocator());
+    try std.testing.expect(std.mem.indexOf(u8, processed.stdout, "<masked>") != null);
+    try std.testing.expect(std.mem.indexOf(u8, processed.stdout, "topsecret") == null);
+    try std.testing.expectEqualStrings(exec_result.stderr, processed.stderr);
 }


### PR DESCRIPTION
**Issue**
runProxy captured stderr from the executor and then never wrote it anywhere. Any command whose useful output lives on stderr was silently truncated to whatever the stdout filter produced.

Concrete case: a repo with a lefthook pre-push hook that enforces code coverage percentage. When the hook fails, git push exits 1 and writes the hook error plus 'failed to push some refs' to stderr. Through ztk the agent saw:

    exit=1
    output: ok

filterGitPush returned 'ok' for the empty stdout, the real failure on stderr was thrown away, and the agent had no idea why the push failed. In practice this causes real churn: agents loop, retry, or give up because the wrapper hides the actual error.

**Fix**
forward result.stderr to the user's stderr via compat.writeStderr. Stdout filtering is unchanged, so secret-masking filters like the env filter still run on failed commands. Tests cover stderr passthrough on both zero and nonzero exit, plus a regression test that env-style sensitive values (API_KEY etc.) stay masked when the underlying command exits nonzero.

**Additional**
ztk has no stderr filters today. Secrets that show up on stderr (URL-embedded credentials in git auth errors, tokens in verbose curl/ssh output) already reach the agent's environment when those commands run outside ztk.

I'm thinking it may be questionable for ztk to do any filtering of secrets at all, as that could well be the responsibility of another tool.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve stderr from wrapped command execution and forward it to stderr output
> Previously, stderr from executed commands was silently discarded, making failures hard to diagnose. A new `processOutput` helper in [proxy.zig](https://github.com/codejunkie99/ztk/pull/14/files#diff-98d2130503baa8ba0db2c2436f270f20b6d6b13fb9f359b7aa079b8da1570fdd) separates stdout filtering/session handling from stderr, returning both via a `ProcessedOutput` struct. In non-test builds, any non-empty stderr is written directly to stderr via `compat.writeStderr`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac95837.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->